### PR TITLE
Add support for an array of maven options instead of only a single commandline option. backward compatible.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ async function run(): Promise<void> {
     const localDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), github.context.sha)
     await io.mkdirP(localDir)
     const localMavenRepo = `local::file://${localDir}`
+    const mavenOptions=core.getInput('maven-options')
     await exec('mvn', ['-version'])
     core.info('Running maven deploy')
     const mavenResult = await exec(
@@ -19,7 +20,7 @@ async function run(): Promise<void> {
       [
         '-B',
         '-X',
-        core.getInput('maven-options'),
+        ...((mavenOptions.constructor === Array) ? mavenOptions : [mavenOptions]),
         '-Dmaven.test.skip=true',
         '-DskipTests',
         `-DaltDeploymentRepository=${localMavenRepo}`,


### PR DESCRIPTION
"splat" the maven options into the command line arguments list of exec; fixes the bug where only a single `maven-options` is allowed. 

This fix is **backward compatible**; you can now either provide a single string or a YAML array of strings with `maven-options`

This PR requires still some testing. 