### PR TITLE
changed maven-options from string to array of strings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   maven-options:
     required: false
     description: 'Extra maven options'
-    default: ''
+    default: []
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ async function run(): Promise<void> {
       [
         '-B',
         '-X',
-        core.getInput('maven-options'),
+        ...(core.getInput('maven-options')),
         '-Dmaven.test.skip=true',
         '-DskipTests',
         `-DaltDeploymentRepository=${localMavenRepo}`,


### PR DESCRIPTION
* this makes its possible to skip tutor and rascal compiler during artifact construction (for speed)
* also necessary because we are losing the gecko configuration during the second run of the tutor