### PR TITLE
change maven-options back to string because arrays are not supported in `with` by github actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   maven-options:
     required: false
     description: 'Extra maven options'
-    default: []
+    default: ''
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ async function run(): Promise<void> {
       [
         '-B',
         '-X',
-        ...(core.getInput('maven-options').split(' ').trim()),
+        ...core.getMultilineInput('maven-options'),
         '-Dmaven.test.skip=true',
         '-DskipTests',
         `-DaltDeploymentRepository=${localMavenRepo}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ async function run(): Promise<void> {
       [
         '-B',
         '-X',
-        ...(core.getInput('maven-options')),
+        ...(core.getInput('maven-options').split(' ').trim()),
         '-Dmaven.test.skip=true',
         '-DskipTests',
         `-DaltDeploymentRepository=${localMavenRepo}`,


### PR DESCRIPTION
This implementation splits the maven-options parameter on the spaces in between the `-D` options, and then splices in the resulting array in the argument parameter array to the call to exec. 

Note that additional spaces inside the options would become problematic because we do not supported nested strings here or any other form of parsing. It's a raw split on spaces. 